### PR TITLE
feat: import reflect-metadata where used to make consuming this library easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ Install package with npm using
 
 ## How to use it
 
-First, make sure you have imported `reflect-metadata` in your app root.
-
-```typescript
-import 'reflect-metadata';
-```
-
 Decorate model properties you want to be sortable with `Sortable` decorator imported from `sortable-properties`.
 
 ```typescript

--- a/src/get-sortable-properties.utility.ts
+++ b/src/get-sortable-properties.utility.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { MetadataKey } from './constants';
 import { Constructible } from './constructible.type';
 

--- a/src/sortable.decorator.ts
+++ b/src/sortable.decorator.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { MetadataKey } from './constants';
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,7 +47,7 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    "types": ["reflect-metadata"] /* Type declaration files to be included in compilation. */,
+    // "types": [] /* Type declaration files to be included in compilation. */,
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */


### PR DESCRIPTION
Before consumers had to import reflect-metadata at their app root to make things work. This pull request deprecates that and makes library easier to use.

Docs are updated.